### PR TITLE
RaiseError: keep consistent with interfaces

### DIFF
--- a/src/Error.jl
+++ b/src/Error.jl
@@ -10,10 +10,7 @@ Raise specific `error` or `ErrorException(message)` when serializing or deserial
 """
 RaiseError(msg::AbstractString) = RaiseError(ErrorException(msg))
 
-# this method is not consistent with the Construct interface,
-# but it's acceptable because it never writes anything to the stream.
-serialize(cons::RaiseError, ::IO, ::Any; contextkw...) = throw(cons.err)
-serialize(cons::RaiseError, ::IO, ::UndefProperty; contextkw...) = throw(cons.err)
 # serialize(cons::RaiseError, ::IO, ::Union{}; contextkw...) = throw(cons.err) # unreachable
 deserialize(cons::RaiseError, ::IO; contextkw...) = throw(cons.err)
+default(cons::RaiseError; contextkw...) = throw(cons.err)
 estimatesize(cons::RaiseError; contextkw...) = ExactSize(0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -134,10 +134,9 @@ end
         @test estimatesize(RaiseError("Invalid data.")) == 0
         @test_throws ErrorException deserialize(RaiseError("Invalid data."), b"")
         @test_throws ValidationError deserialize(RaiseError(ValidationError("Invalid data.")), b"")
-        @test_throws ErrorException serialize(RaiseError("Invalid data."), IOBuffer(), nothing)
-        @test_throws ValidationError serialize(RaiseError(ValidationError("Invalid data.")), IOBuffer(), nothing)
-        @test_throws ErrorException serialize(RaiseError("Invalid data."), IOBuffer(), UndefProperty{Union{}}())
-        @test_throws ValidationError serialize(RaiseError(ValidationError("Invalid data.")), IOBuffer(), UndefProperty{Union{}}())
+        @test_throws ErrorException serialize(RaiseError("Invalid data."), UndefProperty{Union{}}())
+        @test_throws ValidationError serialize(RaiseError(ValidationError("Invalid data.")), UndefProperty{Union{}}())
+        @test_throws MethodError serialize(RaiseError("Invalid data."), nothing)
     end
     @testset "JuliaSerializer" begin
         @test estimatesize(JuliaSerializer()) == UnboundedSize(0)


### PR DESCRIPTION
remove the method incompatible with the interface