### PR TITLE
fix RaiseError test case

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -138,7 +138,11 @@ end
         @test_throws ValidationError deserialize(RaiseError(ValidationError("Invalid data.")), b"")
         @test_throws ErrorException serialize(RaiseError("Invalid data."), UndefProperty{Union{}}())
         @test_throws ValidationError serialize(RaiseError(ValidationError("Invalid data.")), UndefProperty{Union{}}())
-        @test_throws MethodError serialize(RaiseError("Invalid data."), nothing)
+        @static if Base.VERSION >= v"1.10-"
+            @test_throws ArgumentError serialize(RaiseError("Invalid data."), nothing)
+        else
+            @test_throws MethodError serialize(RaiseError("Invalid data."), nothing)
+        end
     end
     @testset "JuliaSerializer" begin
         @test estimatesize(JuliaSerializer()) == UnboundedSize(0)


### PR DESCRIPTION
workaround for serialize RaiseError will throws ArgumentError rather than MethodError after Julia 1.10 #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test conditions for Julia version 1.10 and above to improve compatibility.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->